### PR TITLE
Reusable workflow first approach

### DIFF
--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Build and push to IBM registry for platypus
         if: ${{ inputs.build == 'platypus' }}
         id: platypus_build_push_to_cr
-        uses: docker/build-push-action@v2.6.1
+        uses: docker/build-push-action@v2
         with:
           push: true
           tags: ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -3,11 +3,6 @@ name: Docker image deployment process in IBM Cloud Code Engine
 on:
   workflow_call:
     inputs:
-      #possible values: simple, platypus
-      build:
-        default: simple
-        required: false
-        type: string
       container_registry_namespace:
         required: true
         type: string
@@ -89,7 +84,7 @@ jobs:
           password: ${{ secrets.ibmcloud_api_key }}
 
       - name: Build and push to IBM registry for a simple project
-        if: ${{ inputs.build == 'simple' }}
+        if: github.repository != 'Qiskit/platypus'
         uses: docker/build-push-action@v2
         with:
           push: true
@@ -98,7 +93,7 @@ jobs:
           cache-to: type=inline
       
       - name: Build and push to IBM registry for platypus
-        if: ${{ inputs.build == 'platypus' }}
+        if: github.repository == 'Qiskit/platypus'
         id: platypus_build_push_to_cr
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -3,6 +3,11 @@ name: Docker image deployment process in IBM Cloud Code Engine
 on:
   workflow_call:
     inputs:
+      #possible values: simple, platypus
+      build:
+        default: simple
+        required: false
+        type: string
       container_registry_namespace:
         required: true
         type: string
@@ -48,7 +53,7 @@ jobs:
 
       - name: GH deployment status (start)
         id: gh_deployment
-        uses: bobheadxi/deployments@v0.4.3
+        uses: bobheadxi/deployments@v0.6.2
         with:
           step: start
           token: ${{ github.token }}
@@ -88,15 +93,26 @@ jobs:
           username: iamapikey
           password: ${{ secrets.ibmcloud_api_key }}
 
-      - name: Build and push to IBM registry
+      - name: Build and push to IBM registry for a simple project
+        if: ${{ inputs.build == 'simple' }}
         id: build_push_to_cr
-        uses: docker/build-push-action@v2.6.1
+        uses: docker/build-push-action@v2
         with:
           push: true
           tags: ${{ env.DOCKER_IMAGE_TAG }}
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
           cache-to: type=inline
       
+      - name: Build and push to IBM registry for platypus
+        if: ${{ inputs.build == 'platypus' }}
+        id: platypus_build_push_to_cr
+        uses: docker/build-push-action@v2.6.1
+        with:
+          push: true
+          tags: ${{ env.DOCKER_IMAGE_TAG }}
+          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
+          cache-to: type=inline
+
       - name: Determine Code Engine project and app status
         id: ce_command_choice
         run: |
@@ -124,7 +140,7 @@ jobs:
       
       - name: GH deployment status (finish)
         id: gh_deplyment_finish
-        uses: bobheadxi/deployments@v0.4.3
+        uses: bobheadxi/deployments@v0.6.2
         if: always()
         with:
           step: finish

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -99,7 +99,6 @@ jobs:
       
       - name: Build and push to IBM registry for platypus
         if: github.repository == 'Qiskit/platypus'
-        id: platypus_build_push_to_cr
         uses: docker/build-push-action@v2
         with:
           push: true

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -4,25 +4,30 @@ on:
   workflow_call:
     inputs:
       container_registry_namespace:
-        required: true
+        default: community-digital
+        required: false
         type: string
       code_engine_project:
         required: true
         type: string
       code_engine_registry_secret:
-        required: true
+        default: ibm-container-registry
+        required: false
         type: string
       docker_image_name:
-        required: true
+        default: "8080"
+        required: false
         type: string
       docker_image_port:
         required: true
         type: string
       ibmcloud_region:
-        required: true
+        default: us-south
+        required: false
         type: string
       ibmcloud_resource_group:
-        required: true
+        default: Quantum Community
+        required: false
         type: string
       pr_tag:
         default: pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
First approach to reusable workflow use. As a reference, the result of this work is being managed here: https://github.com/Qiskit/qiskit.org/pull/2397

There are a couple of things that I would like to discuss to know your opinion:
- **One workflow instead of small pieces**: working with this feature it seems that it is more focused to share a complete workflow than generate small jobs connected between them. You can't mix jobs and steps what it makes difficult to share the common parts of a workflow letting out the specific steps (like it could be the build).
- **Specific steps**: in a workflow there may be specific steps which different applications don't need to share. There are different solutions: the use of **if** directly using the name of the repository, using a variable to manage the exception (like I am doing [here](https://github.com/Qiskit/gh-actions/pull/6/files#diff-15cd9f60a6876bfd8dbe62b3349b0dc1c9a4f9a8ef59a2ed03b46a54dda5330bR7)). I would really like to hear your opinion about these options.

Apart from that some interesting changes that we did are:
- New set of nomenclatures to make it easy to read:
<img width="325" alt="Screenshot 2022-01-07 at 15 49 27" src="https://user-images.githubusercontent.com/9059044/148560939-77fda2d7-7fcd-4360-aa6d-7d8a1cdd0585.png">

- New use of environment in the deployment to improve the management as we were doing with vercel:
<img width="163" alt="Screenshot 2022-01-07 at 15 51 41" src="https://user-images.githubusercontent.com/9059044/148561271-edba4d81-0256-4624-9a63-ef83a032465c.png">
<img width="325" alt="Screenshot 2022-01-07 at 15 50 43" src="https://user-images.githubusercontent.com/9059044/148561119-ecbb35db-acef-4139-9de0-1ab7cd184c25.png">

- Updated some dependencies that we had in some github actions: #5 

Fix #5 https://github.com/Qiskit/qiskit.org/issues/2398
Reference: https://github.com/Qiskit/qiskit.org/pull/2397