### PR TITLE
Change Preview env to a new name

### DIFF
--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           step: start
           token: ${{ github.token }}
-          env: Preview
+          env: preview-${{ inputs.pr_tag }}
           auto_inactive: true
           ref: ${{ github.event.pull_request.head.ref }}
 


### PR DESCRIPTION
After some investigations looking into the `env` variable in the _deployment_ github-action it seems that the _Preview_ didn't work as we expected. The idea will change this into a more generic name to match for different projects.

Related with this conversation: https://github.com/Qiskit/gh-actions/pull/10/files#r782761047 