### PR TITLE
add missing cr namespace

### DIFF
--- a/.github/workflows/code-engine-cleanup.yml
+++ b/.github/workflows/code-engine-cleanup.yml
@@ -3,6 +3,10 @@ name: Container Registry and Code Engine clean up
 on:
   workflow_call:
     inputs:
+      container_registry_namespace:
+        default: community-digital
+        required: false
+        type: string
       code_engine_project:
         required: true
         type: string


### PR DESCRIPTION
clean up action failing because of incorrect docker image name:

<img width="570" alt="image" src="https://user-images.githubusercontent.com/13156555/149221361-5291116e-8181-4b7f-8471-3736bc392870.png">


this PR adds the missing CR namespace