### PR TITLE
update deployment lifecycle

### DIFF
--- a/.github/workflows/code-engine-cleanup.yml
+++ b/.github/workflows/code-engine-cleanup.yml
@@ -74,7 +74,6 @@ jobs:
           github-token: ${{ github.token }}
           environment: ${{ inputs.env_name }}
           ref: ${{ env.PREVIEW_REF }}
-          status: success
 
       - name: GH deployment status (start)
         uses: bobheadxi/deployments@v1

--- a/.github/workflows/code-engine-cleanup.yml
+++ b/.github/workflows/code-engine-cleanup.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           ibmcloud login -g "${{ inputs.ibmcloud_resource_group }}" -r "${{ inputs.ibmcloud_region }}" -c "${{ secrets.ibmcloud_account }}" --apikey "${{ secrets.ibmcloud_api_key }}"
 
-      - name: Find GH deployment
+      - name: Check for existing GH deployment
         uses: cloudposse/github-action-seek-deployment@master
         id: find_gh_deployment
         with:
@@ -77,15 +77,15 @@ jobs:
           status: success
 
       - name: GH deployment status (start)
-        if: ${{ steps.find_gh_deployment.outputs.id != '' }}
-        id: gh_deployment
         uses: bobheadxi/deployments@v1
+        id: gh_deployment
+        if: ${{ steps.find_gh_deployment.outputs.id != '' }}
         with:
           step: start
           token: ${{ github.token }}
           env: ${{ inputs.env_name }}
           ref: ${{ env.PREVIEW_REF }}
-          deployment-id: ${{ steps.find_gh_deployment.outputs.id }}
+          deployment_id : ${{ steps.find_gh_deployment.outputs.id }}
 
       - name: Remove Code Engine preview application
         run: |

--- a/.github/workflows/code-engine-cleanup.yml
+++ b/.github/workflows/code-engine-cleanup.yml
@@ -44,8 +44,10 @@ jobs:
         run: |
           if "${{ inputs.env_name == 'Preview' }}" ; then
             echo "PREVIEW_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+            echo "PREVIEW_REF=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           else
             echo "PREVIEW_TAG=`node -p "'${{ inputs.env_name }}'.toLowerCase()"`" >> $GITHUB_ENV
+            echo "PREVIEW_REF=refs/heads/main" >> $GITHUB_ENV
           fi
 
       - name: Create APP_NAME and DOCKER_IMAGE_TAG env variables
@@ -79,12 +81,22 @@ jobs:
           ibmcloud cr region-set global
           ibmcloud cr image-rm "${{ env.DOCKER_IMAGE_TAG }}"
 
-      - name: GH deployment status (destroy deployment)
-        uses: bobheadxi/deployments@v1
+      - name: Find GH deployment
+        uses: cloudposse/github-action-seek-deployment@main
+        id: find_gh_deployment
         with:
-          step: deactivate-env
-          token: ${{ github.token }}
-          env: ${{ inputs.env_name }}
+          github-token: ${{ github.token }}
+          environment: ${{ inputs.env_name }}
+          ref: ${{ env.PREVIEW_TAG }}
+          status: success
+
+      - name: Make GH deployment inactive
+        if: ${{ steps.find_gh_deployment.outputs.id != '' }}
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: '${{ github.token }}'
+          state: 'inactive'
+          deployment-id: ${{ steps.find_gh_deployment.outputs.id }}
 
       - name: GH deployment status (delete environment)
         uses: bobheadxi/deployments@v1

--- a/.github/workflows/code-engine-cleanup.yml
+++ b/.github/workflows/code-engine-cleanup.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           environment: ${{ inputs.env_name }}
-          ref: ${{ env.PREVIEW_TAG }}
+          ref: ${{ env.PREVIEW_REF }}
           status: success
 
       - name: Make GH deployment inactive

--- a/.github/workflows/code-engine-cleanup.yml
+++ b/.github/workflows/code-engine-cleanup.yml
@@ -68,7 +68,7 @@ jobs:
           ibmcloud login -g "${{ inputs.ibmcloud_resource_group }}" -r "${{ inputs.ibmcloud_region }}" -c "${{ secrets.ibmcloud_account }}" --apikey "${{ secrets.ibmcloud_api_key }}"
 
       - name: Find GH deployment
-        uses: cloudposse/github-action-seek-deployment@main
+        uses: cloudposse/github-action-seek-deployment@master
         id: find_gh_deployment
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/code-engine-cleanup.yml
+++ b/.github/workflows/code-engine-cleanup.yml
@@ -47,7 +47,7 @@ jobs:
             echo "PREVIEW_REF=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           else
             echo "PREVIEW_TAG=`node -p "'${{ inputs.env_name }}'.toLowerCase()"`" >> $GITHUB_ENV
-            echo "PREVIEW_REF=main" >> $GITHUB_ENV
+            echo "PREVIEW_REF=${{ github.ref_name }}" >> $GITHUB_ENV
           fi
 
       - name: Create APP_NAME and DOCKER_IMAGE_TAG env variables

--- a/.github/workflows/code-engine-cleanup.yml
+++ b/.github/workflows/code-engine-cleanup.yml
@@ -111,7 +111,7 @@ jobs:
           status: 'inactive'
           auto_inactive: true
           override: false
-          deployment_id: ${{ steps.gh_deployment.outputs.deployment_id }}
+          deployment_id: ${{ steps.find_gh_deployment.outputs.id }}
 
       - name: GH deployment status (delete environment)
         uses: bobheadxi/deployments@v1

--- a/.github/workflows/code-engine-cleanup.yml
+++ b/.github/workflows/code-engine-cleanup.yml
@@ -47,7 +47,7 @@ jobs:
             echo "PREVIEW_REF=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           else
             echo "PREVIEW_TAG=`node -p "'${{ inputs.env_name }}'.toLowerCase()"`" >> $GITHUB_ENV
-            echo "PREVIEW_REF=refs/heads/main" >> $GITHUB_ENV
+            echo "PREVIEW_REF=main" >> $GITHUB_ENV
           fi
 
       - name: Create APP_NAME and DOCKER_IMAGE_TAG env variables

--- a/.github/workflows/code-engine-cleanup.yml
+++ b/.github/workflows/code-engine-cleanup.yml
@@ -67,6 +67,26 @@ jobs:
         run: |
           ibmcloud login -g "${{ inputs.ibmcloud_resource_group }}" -r "${{ inputs.ibmcloud_region }}" -c "${{ secrets.ibmcloud_account }}" --apikey "${{ secrets.ibmcloud_api_key }}"
 
+      - name: Find GH deployment
+        uses: cloudposse/github-action-seek-deployment@main
+        id: find_gh_deployment
+        with:
+          github-token: ${{ github.token }}
+          environment: ${{ inputs.env_name }}
+          ref: ${{ env.PREVIEW_REF }}
+          status: success
+
+      - name: GH deployment status (start)
+        if: ${{ steps.find_gh_deployment.outputs.id != '' }}
+        id: gh_deployment
+        uses: bobheadxi/deployments@v1
+        with:
+          step: start
+          token: ${{ github.token }}
+          env: ${{ inputs.env_name }}
+          ref: ${{ env.PREVIEW_REF }}
+          deployment-id: ${{ steps.find_gh_deployment.outputs.id }}
+
       - name: Remove Code Engine preview application
         run: |
           ibmcloud ce project select -n "${{ inputs.code_engine_project }}"
@@ -81,22 +101,17 @@ jobs:
           ibmcloud cr region-set global
           ibmcloud cr image-rm "${{ env.DOCKER_IMAGE_TAG }}"
 
-      - name: Find GH deployment
-        uses: cloudposse/github-action-seek-deployment@main
-        id: find_gh_deployment
-        with:
-          github-token: ${{ github.token }}
-          environment: ${{ inputs.env_name }}
-          ref: ${{ env.PREVIEW_REF }}
-          status: success
-
-      - name: Make GH deployment inactive
+      - name: GH deployment status (finish)
+        uses: bobheadxi/deployments@v1
         if: ${{ steps.find_gh_deployment.outputs.id != '' }}
-        uses: chrnorm/deployment-status@v2
         with:
-          token: '${{ github.token }}'
-          state: 'inactive'
-          deployment-id: ${{ steps.find_gh_deployment.outputs.id }}
+          step: finish
+          token: ${{ github.token }}
+          env: ${{ inputs.env_name }}
+          status: 'inactive'
+          auto_inactive: true
+          override: false
+          deployment_id: ${{ steps.gh_deployment.outputs.deployment_id }}
 
       - name: GH deployment status (delete environment)
         uses: bobheadxi/deployments@v1

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -54,8 +54,10 @@ jobs:
         run: |
           if "${{ inputs.env_name == 'Preview' }}" ; then
             echo "PREVIEW_TAG=pr-${{ github.event.pull_request.number }}" >> $GITHUB_ENV
+            echo "PREVIEW_REF=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           else
             echo "PREVIEW_TAG=`node -p "'${{ inputs.env_name }}'.toLowerCase()"`" >> $GITHUB_ENV
+            echo "PREVIEW_REF=main" >> $GITHUB_ENV
           fi
 
       - name: Create APP_NAME and DOCKER_IMAGE_TAG env variables
@@ -66,6 +68,14 @@ jobs:
       - name: Fetch content of the PR
         uses: actions/checkout@v3
 
+      - name: Find GH deployment
+        uses: cloudposse/github-action-seek-deployment@main
+        id: find_gh_deployment
+        with:
+          github-token: ${{ github.token }}
+          environment: ${{ inputs.env_name }}
+          ref: ${{ env.PREVIEW_REF }}
+
       - name: GH deployment status (start)
         id: gh_deployment
         uses: bobheadxi/deployments@v1
@@ -73,7 +83,8 @@ jobs:
           step: start
           token: ${{ github.token }}
           env: ${{ inputs.env_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ env.PREVIEW_REF }}
+          deployment-id: ${{ steps.find_gh_deployment.outputs.id }}
 
       - name: Setup IBM Cloud CLI
         run: |

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -77,8 +77,8 @@ jobs:
           ref: ${{ env.PREVIEW_REF }}
 
       - name: GH deployment status (start)
-        uses: bobheadxi/deployments@v1
         id: gh_deployment
+        uses: bobheadxi/deployments@v1
         with:
           step: start
           token: ${{ github.token }}
@@ -115,8 +115,8 @@ jobs:
           password: ${{ secrets.ibmcloud_api_key }}
 
       - name: Build and push to IBM registry for a simple project
-        uses: docker/build-push-action@v3
         if: github.repository != 'Qiskit/platypus'
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: ${{ env.DOCKER_IMAGE_TAG }}
@@ -124,8 +124,8 @@ jobs:
           cache-to: type=inline
 
       - name: Build and push to IBM registry for platypus
-        uses: docker/build-push-action@v3
         if: github.repository == 'Qiskit/platypus'
+        uses: docker/build-push-action@v3
         with:
           push: true
           tags: ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -57,7 +57,7 @@ jobs:
             echo "PREVIEW_REF=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           else
             echo "PREVIEW_TAG=`node -p "'${{ inputs.env_name }}'.toLowerCase()"`" >> $GITHUB_ENV
-            echo "PREVIEW_REF=main" >> $GITHUB_ENV
+            echo "PREVIEW_REF=${{ github.ref_name }}" >> $GITHUB_ENV
           fi
 
       - name: Create APP_NAME and DOCKER_IMAGE_TAG env variables

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Fetch content of the PR
         uses: actions/checkout@v3
 
-      - name: Find GH deployment
+      - name: Check for existing GH deployment
         uses: cloudposse/github-action-seek-deployment@master
         id: find_gh_deployment
         with:
@@ -77,14 +77,14 @@ jobs:
           ref: ${{ env.PREVIEW_REF }}
 
       - name: GH deployment status (start)
-        id: gh_deployment
         uses: bobheadxi/deployments@v1
+        id: gh_deployment
         with:
           step: start
           token: ${{ github.token }}
           env: ${{ inputs.env_name }}
           ref: ${{ env.PREVIEW_REF }}
-          deployment-id: ${{ steps.find_gh_deployment.outputs.id }}
+          deployment_id: ${{ steps.find_gh_deployment.outputs.id }}
 
       - name: Setup IBM Cloud CLI
         run: |
@@ -115,8 +115,8 @@ jobs:
           password: ${{ secrets.ibmcloud_api_key }}
 
       - name: Build and push to IBM registry for a simple project
-        if: github.repository != 'Qiskit/platypus'
         uses: docker/build-push-action@v3
+        if: github.repository != 'Qiskit/platypus'
         with:
           push: true
           tags: ${{ env.DOCKER_IMAGE_TAG }}
@@ -124,8 +124,8 @@ jobs:
           cache-to: type=inline
 
       - name: Build and push to IBM registry for platypus
-        if: github.repository == 'Qiskit/platypus'
         uses: docker/build-push-action@v3
+        if: github.repository == 'Qiskit/platypus'
         with:
           push: true
           tags: ${{ env.DOCKER_IMAGE_TAG }}

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Find GH deployment
-        uses: cloudposse/github-action-seek-deployment@main
+        uses: cloudposse/github-action-seek-deployment@master
         id: find_gh_deployment
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -167,9 +167,9 @@ jobs:
         with:
           step: finish
           token: ${{ github.token }}
-          env: ${{ steps.gh_deployment.outputs.env }}
+          env: ${{ inputs.env_name }}
           status: ${{ job.status }}
-          auto_inactive: false
+          auto_inactive: true
           override: false
           deployment_id: ${{ steps.gh_deployment.outputs.deployment_id }}
           env_url: ${{ steps.ce_app_creation.outputs.preview_url }}


### PR DESCRIPTION
## Changes

- make deployment `inactive` on clean action
- reuse existing deployments on multiple updates to same PR

## Implementation details

- use `cloudposse/github-action-seek-deployment` to find current deployment
- use `bobheadxi/deployments` to update deployment status

## How to read this PR

- review usage of [cloudposse/github-action-seek-deployment@main](https://github.com/marketplace/actions/seek-deployment)
- review usage of [bobheadxi/deployments@v1](https://github.com/marketplace/actions/github-deployments)
- review deploy steps
- review clean steps
- use this [test PR](https://github.com/Qiskit/saiba/pull/258) to open/close/commit and see the [deployment changes](https://github.com/Qiskit/saiba/deployments).


