### PR TITLE
Pass deploy key to clone Qiskit/textbook

### DIFF
--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -44,6 +44,8 @@ on:
         required: false
       mongodb_uri:
         required: false
+      textbook_repo_clone_key:
+        required: false
 
 jobs:
   deploy:
@@ -124,6 +126,7 @@ jobs:
             IBMID_CLIENT_ID=${{ secrets.ibmid_client_id }}
             IBMID_CLIENT_SECRET=${{ secrets.ibmid_client_secret }}
             MONGODB_URI=${{ secrets.mongodb_uri }}
+            TEXTBOOK_REPO_CLONE_KEY=${{ secrets.textbook_repo_clone_key }}
 
       - name: Determine Code Engine project and app status
         id: ce_command_choice


### PR DESCRIPTION
## Changes

Qiskit/textbook is private, so we need to pass a deploy key to the dockerfile to clone that repo and pull the contents.

For context: https://github.com/Qiskit/platypus/pull/1845