### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -147,9 +147,9 @@ jobs:
         run: |
           ibmcloud ce project select -n "${{ inputs.code_engine_project }}"
           if ibmcloud ce app list -q | grep "${{ env.APP_NAME }}" ; then
-            echo "::set-output name=command::update"
+            echo "command=update" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=command::create"
+            echo "command=create" >> $GITHUB_OUTPUT
           fi
 
       - name: Create a new preview application in Code Engine
@@ -163,9 +163,9 @@ jobs:
             --cpu 0.25 \
             --memory 0.5G \
             --min 1
-          echo "::set-output name=preview_url::$(\
+          echo "preview_url=$(\
             ibmcloud ce app get --name "${{ env.APP_NAME }}" --output url
-          )"
+          )" >> $GITHUB_OUTPUT
 
       - name: GH deployment status (finish)
         uses: bobheadxi/deployments@v1


### PR DESCRIPTION
## Description

Resolve  #42 

Update `.github/workflows/code-engine-preview.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
if ibmcloud ce app list -q | grep "${{ env.APP_NAME }}" ; then
  echo "::set-output name=command::update"
else
  echo "::set-output name=command::create"
fi
```

**TO-BE**

```yml
if ibmcloud ce app list -q | grep "${{ env.APP_NAME }}" ; then
  echo "command=update" >> $GITHUB_OUTPUT
else
  echo "command=create" >> $GITHUB_OUTPUT
fi
```