### PR TITLE
Make Preview workflow generic to multiple projects 

### DIFF
--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -137,7 +137,16 @@ jobs:
           password: ${{ secrets.ibmcloud_api_key }}
 
       - name: Build and push to IBM registry for a simple project
-        if: github.repository != 'Qiskit/platypus'
+        if: github.repository != 'Qiskit/qiskit.org' && github.repository != 'Qiskit/platypus'
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ env.DOCKER_IMAGE_TAG }}
+          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
+          cache-to: type=inline
+
+      - name: Build and push to IBM registry for qiskit.org
+        if: github.repository == 'Qiskit/qiskit.org'
         uses: docker/build-push-action@v3
         with:
           push: true

--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -21,6 +21,8 @@ on:
         default: '8080'
         required: false
         type: string
+      build_args:
+        required: false
       ibmcloud_region:
         default: us-south
         required: false
@@ -136,7 +138,7 @@ jobs:
           username: iamapikey
           password: ${{ secrets.ibmcloud_api_key }}
 
-      - name: Build and push to IBM registry for a simple project
+      - name: Build and push to IBM registry
         if: github.repository != 'Qiskit/qiskit.org' && github.repository != 'Qiskit/platypus'
         uses: docker/build-push-action@v3
         with:
@@ -144,6 +146,7 @@ jobs:
           tags: ${{ env.DOCKER_IMAGE_TAG }}
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
           cache-to: type=inline
+          build-args: ${{ inputs.build_args  }}
 
       - name: Build and push to IBM registry for qiskit.org
         if: github.repository == 'Qiskit/qiskit.org'


### PR DESCRIPTION
Right now, only two projects are using the Preview workflow: qiskit.org and platypus. Both of their config is specific to them, such as setting NUXT env variables or `IBMID_CLIENT_ID`.

qiskit-sphinx-theme wants to start using this workflow and it doesn't use these env vars. 

So, this adds a generic setup for projects that allows them to set the `BUILD_ARGS` via a new `build_args` argument to the Action.

## Preps for migrating platypus and qiskit.org

Once this Action is published, then we can migrate qiskit.org and platypus to start setting their BUILD_ARGs directly via the new `build_args` input. 

Once that is landed, we can then remove the custom setup here and switch them to use this new generic action.