### PR TITLE
Add missing `type` to Preview workflow input

### DIFF
--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -23,6 +23,7 @@ on:
         type: string
       build_args:
         required: false
+        type: string
       ibmcloud_region:
         default: us-south
         required: false


### PR DESCRIPTION
I missed that that `type` is required. This has broken qiskit.org previews.