### PR TITLE
Update code-engine-preview.yml

### DIFF
--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -71,6 +71,8 @@ on:
         required: false
       NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_UT30:
         required: false
+      AIRTABLE_API_KEY:
+        required: false
 
 jobs:
   deploy:
@@ -158,6 +160,7 @@ jobs:
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
           cache-to: type=inline
           build-args: |
+            AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
             NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_ANALYTICS_CATEGORY: ${{ secrets.NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_ANALYTICS_CATEGORY }}
             NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_INSTANCE_ID: ${{ secrets.NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_INSTANCE_ID }}
             NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_ANALYTICS_KEY: ${{ secrets.NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_ANALYTICS_KEY_STAGING }}


### PR DESCRIPTION
## Changes

[This issue](https://github.com/Qiskit/qiskit.org/issues/3321) changes the way qiskit.org builds and deploys its preview version and the ARITABLE_API_KEY is required to generate the static site.

To this end, the ARITABLE_API_KEY has been added to the secrets and build arguments for qiskit.org