### PR TITLE
update cli version

### DIFF
--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Setup IBM Cloud CLI
         run: |
-          curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
+          curl -fsSL https://download.clis.cloud.ibm.com/ibm-cloud-cli/2.20.0/IBM_Cloud_CLI_2.20.0_amd64.tar.gz | sh
           ibmcloud --version
           ibmcloud config --check-version=false
           ibmcloud plugin install -f code-engine


### PR DESCRIPTION
## Changes

use `ibmcloud` CLI version 2.20

## Implementation details

change download link to version 2.20 of `ibmcloud` CLI instead of latest version

## How to read this PR

- review download link
- confirm preview working again

