### PR TITLE
feat: replace Airtable API key with access token

### DIFF
--- a/.github/workflows/code-engine-preview.yml
+++ b/.github/workflows/code-engine-preview.yml
@@ -71,7 +71,7 @@ on:
         required: false
       NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_UT30:
         required: false
-      AIRTABLE_API_KEY:
+      AIRTABLE_ACCESS_TOKEN:
         required: false
 
 jobs:
@@ -162,7 +162,7 @@ jobs:
           cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
           cache-to: type=inline
           build-args: |
-            AIRTABLE_API_KEY=${{ secrets.AIRTABLE_API_KEY }}
+            AIRTABLE_ACCESS_TOKEN=${{ secrets.AIRTABLE_ACCESS_TOKEN }}
             NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_ANALYTICS_CATEGORY=${{ secrets.NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_ANALYTICS_CATEGORY }}
             NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_INSTANCE_ID=${{ secrets.NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_INSTANCE_ID }}
             NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_ANALYTICS_KEY=${{ secrets.NUXT_PUBLIC_IBM_ANALYTICS_SEGMENT_ANALYTICS_KEY_STAGING }}


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

Airtable API keys are deprecated if favour of access tokens: https://github.com/Qiskit/qiskit.org/issues/3028

This PR makes the necessary changes for https://github.com/Qiskit/qiskit.org/pull/3604

**IMPORTANT:** Please also add the `AIRTABLE_ACCESS_TOKEN` secret to this repository. The value can be found in our team's password manager. The `AIRTABLE_API_KEY` secret can be deleted after that. @vabarbosa